### PR TITLE
コードのミスを修正

### DIFF
--- a/books/compiling-pattern-matching/pattern_matching_in_other_languages.md
+++ b/books/compiling-pattern-matching/pattern_matching_in_other_languages.md
@@ -342,7 +342,7 @@ final class Stone extends Enum<Stone> {
     }
 
     public static final Stone BLACK = new Stone("BLACK", 0);
-    public static final Stone WHITE = new Stone("WHITE, 1);
+    public static final Stone WHITE = new Stone("WHITE", 1);
 
     private static final Stone ENUM$VALUES[] = {BLACK, WHITE};
 }
@@ -429,7 +429,7 @@ switch (c) {
 // 定義
 sealed interface Cell {}
 record Full(Stone s) implements Cell {}
-record Empty() interface Cell {}
+record Empty() implements Cell {}
 
 // 生成とパターンマッチ
 Cell c = new Empty();


### PR DESCRIPTION
修正内容には関係ないですが、

abstract class Cell {
    private Cell() {}

    final static class Full extends Cell {
        Stone value;
    }
    final static class Empty extends Cell {}
}

とすることで勝手に新しいクラスを作らせることは防げます(パターンマッチに対する網羅性検査の役には全く立ちませんが)。