### PR TITLE
incAge がコンパイルできないのを修正

### DIFF
--- a/books/introduction-to-idris/types-and-datatypes.md
+++ b/books/introduction-to-idris/types-and-datatypes.md
@@ -246,7 +246,7 @@ record { age $= (+ 1), name = "anonymous" }
 
 ```idris
 incAge: Person -> Person
-incAge = record { age $= $(+ 1) }
+incAge = record { age $= (+ 1) }
 ```
 
 なので実際に使うときは `record { age $= (+ 1) } p` のようにレコード `p` を引数として渡すことになります。


### PR DESCRIPTION
## 概要

例を参考に、以下のような `Person.idr` を用意し、 `idris Person.idr` したところエラーが発生しました。

```idris
record Person where
    constructor MkPerson
    age: Integer
    name: String

incAge: Person -> Person
incAge = record { age $= $(+ 1) }
```

```
Type checking ./Person.idr
Person.idr:7:23:
  |
7 | incAge = record { age $= $(+ 1) }
  |                       ^
unexpected '$'
expecting "->" or '}'
```

直前の  `record` の例を参考に `$(+ 1)` の `$` を消したところ、コンパイルが通り、想定通りの挙動をしていたのでPRを作成しました。

## 動作確認

```diff
-incAge = record { age $= $(+ 1) }
+incAge = record { age $= (+ 1) }
```

```
*Person> incAge (MkPerson 29 "neglect_yp")
MkPerson 30 "neglect_yp" : Person
```